### PR TITLE
Fix sponsorship info; make link more visible

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -196,6 +196,12 @@
           color: #ffffff;
         "
       >
+        <h2>Sponsors</h2>
+        <p>We are especially grateful to our sponsors who've helped make this event possible:</p>
+        <ul>
+            <li><b><a href="https://firebirdsrestaurants.com/chattanooga">Firebirds Wood Fired Grill</a></b></li>
+            <li><b><a href="https://chattanooga.gov">The City of Chattanooga</a></b></li>
+        </ul>
         <p>
           Would you like to help sponsor the Gig City Data Jam?  We could use your help.  <strong><a href="./sponsor-us.html">Become a sponsor</a> today!</strong>
         </p>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -182,6 +182,26 @@
           </form>
         </div>
       </div>
+
+
+      <div
+        class="info-box"
+        style="
+          padding: 20px;
+          border-radius: 10px;
+          margin-bottom: 20px;
+          width: 100%;
+          max-width: 715px;
+          background-color: rgba(0, 0, 68, 0.8);
+          color: #ffffff;
+        "
+      >
+        <p>
+          Would you like to help sponsor the Gig City Data Jam?  We could use your help.  <strong><a href="./sponsor-us.html">Become a sponsor</a> today!</strong>
+        </p>
+      </div>
+
+
     </div>
     <footer
       class="footer text-white text-center p-3"

--- a/frontend/sponsor-us.html
+++ b/frontend/sponsor-us.html
@@ -75,9 +75,8 @@
       <div class="contact-info">
         <p>
           <strong>Email:</strong>
-          <a href="mailto:opendata@chattanooga.gov">opendata@chattanooga.gov</a>
+          <a href="mailto:DataJam@symfu.com?subject=Sponsorship">DataJam@symfu.com</a>
         </p>
-        <p><strong>Phone:</strong> (423) 643-6333</p>
       </div>
       <a href="index.html" class="home-button">Home</a>
     </div>


### PR DESCRIPTION
Since I've been handling sponsorship I set my e-mail as the contact, instead of the city.  I'm sure it would reach me eventually, but hopefully this stops some forwarding from happening.

Also, I wanted to make sponsorship info a little more visible on the main page.  I wasn't sure how long potential sponsors would spend on the site and wanted to make it as easy as possible to reach out.